### PR TITLE
change version of common service dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.47</version>
+      <version>0.0.49</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
The pom has been changed to point to version 0.0.49 of census-int-common-service, which does not have dependencies on spring-integration-amqp or spring-rabbit. This census-int-eq-launcher service is used by the eq-flusher utility, which currently has to exclude the spring-integration-amqp and spring-rabbit dependencies in its pom. Once this version points to 0.0.49 then the exclusions can be removed from the eq-flusher.