### PR TITLE
CR-755_Pass_FormType_to_EQ

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/EqLaunchService.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/EqLaunchService.java
@@ -16,12 +16,18 @@ public interface EqLaunchService {
       CaseContainerDTO caseContainer,
       String userId,
       String questionnaireId,
+      String formType,
       String accountServiceUrl,
       String accountServiceLogoutUrl,
       KeyStore keyStore)
       throws CTPException;
 
   String getEqFlushLaunchJwe(
-      Language language, Source source, Channel channel, String questionnaireId, KeyStore keyStore)
+      Language language,
+      Source source,
+      Channel channel,
+      String questionnaireId,
+      String formType,
+      KeyStore keyStore)
       throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/EqLaunchServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/EqLaunchServiceImpl.java
@@ -33,6 +33,7 @@ public class EqLaunchServiceImpl implements EqLaunchService {
       CaseContainerDTO caseContainer,
       String userId,
       String questionnaireId,
+      String formType,
       String accountServiceUrl,
       String accountServiceLogoutUrl,
       KeyStore keyStore)
@@ -47,6 +48,7 @@ public class EqLaunchServiceImpl implements EqLaunchService {
             userId,
             null,
             questionnaireId,
+            formType,
             accountServiceUrl,
             accountServiceLogoutUrl);
 
@@ -54,12 +56,26 @@ public class EqLaunchServiceImpl implements EqLaunchService {
   }
 
   public String getEqFlushLaunchJwe(
-      Language language, Source source, Channel channel, String questionnaireId, KeyStore keyStore)
+      Language language,
+      Source source,
+      Channel channel,
+      String questionnaireId,
+      String formType,
+      KeyStore keyStore)
       throws CTPException {
 
     Map<String, Object> payload =
         createPayloadMap(
-            language, source, channel, null, null, ROLE_FLUSHER, questionnaireId, null, null);
+            language,
+            source,
+            channel,
+            null,
+            null,
+            ROLE_FLUSHER,
+            questionnaireId,
+            formType,
+            null,
+            null);
 
     return codec.encrypt(payload, "authentication", keyStore);
   }
@@ -93,6 +109,7 @@ public class EqLaunchServiceImpl implements EqLaunchService {
       String userId,
       String role,
       String questionnaireId,
+      String formType,
       String accountServiceUrl,
       String accountServiceLogoutUrl)
       throws CTPException {
@@ -143,7 +160,7 @@ public class EqLaunchServiceImpl implements EqLaunchService {
 
     payload.computeIfAbsent("eq_id", (k) -> "census"); // hardcoded for rehearsal
     payload.computeIfAbsent("period_id", (k) -> "2019"); // hardcoded for rehearsal
-    payload.computeIfAbsent("form_type", (k) -> "individual_gb_eng"); // hardcoded for rehearsal
+    payload.computeIfAbsent("form_type", (k) -> formType);
 
     log.with("payload", payload).debug("Payload for EQ");
 

--- a/src/test/java/uk/gov/ons/ctp/integration/eqlaunch/crypto/CodecTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/eqlaunch/crypto/CodecTest.java
@@ -259,7 +259,7 @@ public class CodecTest {
     test.put("questionnaire_id", "11100000009");
     test.put("eq_id", "census");
     test.put("period_id", "2019");
-    test.put("form_type", "individual_gb_eng");
+    test.put("form_type", "H");
     test.put("survey", "CENSUS");
 
     String jwe = codec.encrypt(test, "encryption", keyStoreEncryption);

--- a/src/test/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/TestEqLaunchService_payloadCreation.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/TestEqLaunchService_payloadCreation.java
@@ -236,7 +236,7 @@ public class TestEqLaunchService_payloadCreation {
     expectedMap.put("questionnaire_id", "11100000009");
     expectedMap.put("eq_id", "census");
     expectedMap.put("period_id", "2019");
-    expectedMap.put("form_type", "individual_gb_eng");
+    expectedMap.put("form_type", "H");
     expectedMap.put("survey", "CENSUS");
 
     // create params for code under test
@@ -246,6 +246,7 @@ public class TestEqLaunchService_payloadCreation {
     CaseContainerDTO caseContainer = new CaseContainerDTO();
     String userId = "1234567890";
     String questionnaireId = "11100000009";
+    String formType = "H";
     String accountServiceUrl = "http://localhost:9092/start";
     String accountServiceLogoutUrl = "http://localhost:9092/start/save-and-exit";
 
@@ -271,6 +272,7 @@ public class TestEqLaunchService_payloadCreation {
             userId,
             null,
             questionnaireId,
+            formType,
             accountServiceUrl,
             accountServiceLogoutUrl);
 
@@ -288,6 +290,7 @@ public class TestEqLaunchService_payloadCreation {
             caseContainer,
             userId,
             questionnaireId,
+            formType,
             accountServiceUrl,
             accountServiceLogoutUrl,
             keyStoreEncryption);
@@ -336,18 +339,28 @@ public class TestEqLaunchService_payloadCreation {
     expectedMap.put("questionnaire_id", "11100000009");
     expectedMap.put("eq_id", "census");
     expectedMap.put("period_id", "2019");
-    expectedMap.put("form_type", "individual_gb_eng");
+    expectedMap.put("form_type", "H");
 
     // create params for code under test
     Language language = Language.ENGLISH;
     Source source = Source.RESPONDENT_HOME;
     Channel channel = Channel.RH;
     String questionnaireId = "11100000009";
+    String formType = "H";
 
     // Run code under to test to get the payload map.
     Map<String, Object> payloadMapFromComplexCall =
         eqLaunchService.createPayloadMap(
-            language, source, channel, null, null, "flusher", questionnaireId, null, null);
+            language,
+            source,
+            channel,
+            null,
+            null,
+            "flusher",
+            questionnaireId,
+            formType,
+            null,
+            null);
 
     assertEquals(
         "expectedMap should equal the cleaned map from the complex call",
@@ -357,7 +370,7 @@ public class TestEqLaunchService_payloadCreation {
     // Run code under test to get encrypted payload string
     String payloadStringFromSimpleCall =
         eqLaunchService.getEqFlushLaunchJwe(
-            language, source, channel, questionnaireId, keyStoreEncryption);
+            language, source, channel, questionnaireId, formType, keyStoreEncryption);
 
     // decrypt it
     String decrypted = codec.decrypt(payloadStringFromSimpleCall, keyStoreDecryption);
@@ -396,7 +409,7 @@ public class TestEqLaunchService_payloadCreation {
     expectedMap.put("questionnaire_id", "11100000009");
     expectedMap.put("eq_id", "census");
     expectedMap.put("period_id", "2019");
-    expectedMap.put("form_type", "individual_gb_eng");
+    expectedMap.put("form_type", "H");
     expectedMap.put("case_type", caseData.getCaseType());
     expectedMap.put("collection_exercise_sid", caseData.getCollectionExerciseId().toString());
     expectedMap.put("region_code", "GB-ENG");
@@ -413,6 +426,7 @@ public class TestEqLaunchService_payloadCreation {
     Source source = Source.CONTACT_CENTRE_API;
     Channel channel = Channel.CC;
     String questionnaireId = "11100000009";
+    String formType = "H";
     String agentId = "123456";
     String accountServiceLogoutUrl = "https://localhost/questionnaireSaved";
 
@@ -426,6 +440,7 @@ public class TestEqLaunchService_payloadCreation {
             agentId,
             null,
             questionnaireId,
+            formType,
             null,
             accountServiceLogoutUrl);
 
@@ -443,6 +458,7 @@ public class TestEqLaunchService_payloadCreation {
             caseData,
             agentId,
             questionnaireId,
+            formType,
             null,
             accountServiceLogoutUrl,
             keyStoreEncryption);


### PR DESCRIPTION
# Motivation and Context
FormType no longer hard coded as part of the JWE token payload but passed in to the method signature as part of the client request to create the JWE token.

# What has changed
Addition of formType to EqLaunchService method signatures and inclusion of passed value in JWE payload creation rather than use of hardcoded value.

# How to test?
Unit tests amended to use passed in value. 