### PR TITLE
CR-1205 encrypt 'responseId' claim

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/crypto/EQJOSEProvider.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/crypto/EQJOSEProvider.java
@@ -17,7 +17,7 @@ public interface EQJOSEProvider {
    * @param keyPurpose e.g. authentication
    * @param keyStore Store of asymmetric keys for signing and encryption
    * @return String representing encrypted JWE token
-   * @throws CTPException
+   * @throws CTPException on error
    */
   String encrypt(Map<String, Object> claims, String keyPurpose, KeyStore keyStore)
       throws CTPException;
@@ -28,7 +28,7 @@ public interface EQJOSEProvider {
    * @param jwe JSON Web Encrypted token to decrypt.
    * @param keyStore Store of asymmetric keys for signing and encryption
    * @return String representing JWE payload
-   * @throws CTPException
+   * @throws CTPException on error
    */
   String decrypt(String jwe, KeyStore keyStore) throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/crypto/JWEHelper.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/crypto/JWEHelper.java
@@ -26,8 +26,8 @@ public class JWEHelper {
    *
    * @param jws payload
    * @param key cryptographic key to use for encryption
-   * @return
-   * @throws CTPException
+   * @return encrypted result
+   * @throws CTPException on error
    */
   public String encrypt(JWSObject jws, Key key) throws CTPException {
     log.with(key.getKid()).debug("Encrypting with public key");
@@ -86,7 +86,7 @@ public class JWEHelper {
    * @param jwe JWE encrypted String
    * @param key Cryptographic key to decrypt JWE
    * @return JWSObject representing payload
-   * @throws CTPException
+   * @throws CTPException on error
    */
   public JWSObject decrypt(String jwe, Key key) throws CTPException {
 

--- a/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/crypto/JWEHelper.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/crypto/JWEHelper.java
@@ -46,6 +46,7 @@ public class JWEHelper {
     }
   }
 
+  @SuppressWarnings("deprecation")
   private JWEHeader buildHeader(Key key) {
 
     // We HAVE to use the deprecated Algo to remain compatible with EQ

--- a/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/crypto/JWSHelper.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/crypto/JWSHelper.java
@@ -30,7 +30,7 @@ public class JWSHelper {
    * @param claims to be signed
    * @param key with which to sign claims
    * @return JWSObject representing JWS token
-   * @throws CTPException
+   * @throws CTPException on error
    */
   public JWSObject encode(Map<String, Object> claims, Key key) throws CTPException {
 
@@ -69,9 +69,9 @@ public class JWSHelper {
   /**
    * Return key hint (Id) from JWS header
    *
-   * @param jwsObject
+   * @param jwsObject JWS object
    * @return String representing Key hint from header
-   * @throws CTPException
+   * @throws CTPException on error
    */
   public String getKid(JWSObject jwsObject) throws CTPException {
     String keyId = jwsObject.getHeader().getKeyID();
@@ -85,10 +85,10 @@ public class JWSHelper {
   /**
    * Check the signature of this JWS object against the provided Key.
    *
-   * @param jwsObject
-   * @param key
+   * @param jwsObject JWS object
+   * @param key key
    * @return JWS claims
-   * @throws CTPException
+   * @throws CTPException on error
    */
   public String decode(JWSObject jwsObject, Key key) throws CTPException {
     try {

--- a/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/crypto/Key.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/crypto/Key.java
@@ -21,7 +21,8 @@ public class Key {
   /**
    * Return a JWK from Pem-encoded string
    *
-   * @throws CTPException
+   * @return JWK
+   * @throws CTPException on error
    */
   public JWK getJWK() throws CTPException {
     try {

--- a/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/crypto/KeyStore.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/crypto/KeyStore.java
@@ -68,7 +68,7 @@ public class KeyStore {
    * Get key by Id
    *
    * @param kid key Id
-   * @return
+   * @return optional key
    */
   public Optional<Key> getKeyById(String kid) {
     if (keys.getKeys().containsKey(kid)) {

--- a/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/crypto/KeyStore.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/crypto/KeyStore.java
@@ -23,6 +23,7 @@ public class KeyStore {
    * @param cryptoKeys JSON String of cryptographic keys.
    * @throws CTPException if failure to read keys.
    */
+  @SuppressWarnings("deprecation")
   public KeyStore(String cryptoKeys) throws CTPException {
 
     ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/EqLaunchCoreData.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/EqLaunchCoreData.java
@@ -1,0 +1,30 @@
+package uk.gov.ons.ctp.integration.eqlaunch.service;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.experimental.SuperBuilder;
+import uk.gov.ons.ctp.common.domain.Channel;
+import uk.gov.ons.ctp.common.domain.Language;
+import uk.gov.ons.ctp.common.domain.Source;
+import uk.gov.ons.ctp.integration.eqlaunch.crypto.KeyStore;
+
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder(toBuilder = true)
+@Data
+public class EqLaunchCoreData {
+  @NonNull private Language language;
+  @NonNull private Source source;
+  @NonNull private Channel channel;
+  @NonNull private String questionnaireId;
+  @NonNull private String formType;
+  @NonNull private KeyStore keyStore;
+  @NonNull private String salt;
+
+  public EqLaunchCoreData coreCopy() {
+    return this.toBuilder().build();
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/EqLaunchData.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/EqLaunchData.java
@@ -1,0 +1,24 @@
+package uk.gov.ons.ctp.integration.eqlaunch.service;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import uk.gov.ons.ctp.common.domain.Channel;
+import uk.gov.ons.ctp.common.domain.Language;
+import uk.gov.ons.ctp.common.domain.Source;
+import uk.gov.ons.ctp.integration.eqlaunch.crypto.KeyStore;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Data
+public class EqLaunchData {
+  @NonNull private Language language;
+  @NonNull private Source source;
+  @NonNull private Channel channel;
+  @NonNull private String questionnaireId;
+  @NonNull private String formType;
+  @NonNull private KeyStore keyStore;
+  @NonNull private String salt;
+}

--- a/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/EqLaunchData.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/EqLaunchData.java
@@ -2,23 +2,19 @@ package uk.gov.ons.ctp.integration.eqlaunch.service;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NonNull;
-import uk.gov.ons.ctp.common.domain.Channel;
-import uk.gov.ons.ctp.common.domain.Language;
-import uk.gov.ons.ctp.common.domain.Source;
-import uk.gov.ons.ctp.integration.eqlaunch.crypto.KeyStore;
+import lombok.experimental.SuperBuilder;
+import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerDTO;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
 @Data
-public class EqLaunchData {
-  @NonNull private Language language;
-  @NonNull private Source source;
-  @NonNull private Channel channel;
-  @NonNull private String questionnaireId;
-  @NonNull private String formType;
-  @NonNull private KeyStore keyStore;
-  @NonNull private String salt;
+public class EqLaunchData extends EqLaunchCoreData {
+  @NonNull private CaseContainerDTO caseContainer;
+  @NonNull private String userId;
+  private String accountServiceUrl;
+  private String accountServiceLogoutUrl;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/EqLaunchService.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/EqLaunchService.java
@@ -1,17 +1,9 @@
 package uk.gov.ons.ctp.integration.eqlaunch.service;
 
 import uk.gov.ons.ctp.common.error.CTPException;
-import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerDTO;
 
 public interface EqLaunchService {
+  String getEqLaunchJwe(EqLaunchData launchData) throws CTPException;
 
-  String getEqLaunchJwe(
-      EqLaunchData launchData,
-      CaseContainerDTO caseContainer,
-      String userId,
-      String accountServiceUrl,
-      String accountServiceLogoutUrl)
-      throws CTPException;
-
-  String getEqFlushLaunchJwe(EqLaunchData launchData) throws CTPException;
+  String getEqFlushLaunchJwe(EqLaunchCoreData launchData) throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/EqLaunchService.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/EqLaunchService.java
@@ -19,7 +19,8 @@ public interface EqLaunchService {
       String formType,
       String accountServiceUrl,
       String accountServiceLogoutUrl,
-      KeyStore keyStore)
+      KeyStore keyStore,
+      String salt)
       throws CTPException;
 
   String getEqFlushLaunchJwe(
@@ -28,6 +29,7 @@ public interface EqLaunchService {
       Channel channel,
       String questionnaireId,
       String formType,
-      KeyStore keyStore)
+      KeyStore keyStore,
+      String salt)
       throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/EqLaunchService.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/EqLaunchService.java
@@ -1,35 +1,17 @@
 package uk.gov.ons.ctp.integration.eqlaunch.service;
 
-import uk.gov.ons.ctp.common.domain.Channel;
-import uk.gov.ons.ctp.common.domain.Language;
-import uk.gov.ons.ctp.common.domain.Source;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerDTO;
-import uk.gov.ons.ctp.integration.eqlaunch.crypto.KeyStore;
 
 public interface EqLaunchService {
 
   String getEqLaunchJwe(
-      Language language,
-      Source source,
-      Channel channel,
+      EqLaunchData launchData,
       CaseContainerDTO caseContainer,
       String userId,
-      String questionnaireId,
-      String formType,
       String accountServiceUrl,
-      String accountServiceLogoutUrl,
-      KeyStore keyStore,
-      String salt)
+      String accountServiceLogoutUrl)
       throws CTPException;
 
-  String getEqFlushLaunchJwe(
-      Language language,
-      Source source,
-      Channel channel,
-      String questionnaireId,
-      String formType,
-      KeyStore keyStore,
-      String salt)
-      throws CTPException;
+  String getEqFlushLaunchJwe(EqLaunchData launchData) throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/EqLaunchServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/EqLaunchServiceImpl.java
@@ -13,14 +13,12 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.bouncycastle.util.encoders.Hex;
-import uk.gov.ons.ctp.common.domain.Channel;
-import uk.gov.ons.ctp.common.domain.Language;
 import uk.gov.ons.ctp.common.domain.Source;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.error.CTPException.Fault;
 import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerDTO;
 import uk.gov.ons.ctp.integration.eqlaunch.crypto.Codec;
-import uk.gov.ons.ctp.integration.eqlaunch.crypto.KeyStore;
+import uk.gov.ons.ctp.integration.eqlaunch.service.EqLaunchData;
 import uk.gov.ons.ctp.integration.eqlaunch.service.EqLaunchService;
 
 public class EqLaunchServiceImpl implements EqLaunchService {
@@ -29,62 +27,29 @@ public class EqLaunchServiceImpl implements EqLaunchService {
   private static final String ROLE_FLUSHER = "flusher";
   private Codec codec = new Codec();
 
+  @Override
   public String getEqLaunchJwe(
-      Language language,
-      Source source,
-      Channel channel,
+      EqLaunchData launchData,
       CaseContainerDTO caseContainer,
       String userId,
-      String questionnaireId,
-      String formType,
       String accountServiceUrl,
-      String accountServiceLogoutUrl,
-      KeyStore keyStore,
-      String salt)
+      String accountServiceLogoutUrl)
       throws CTPException {
 
     Map<String, Object> payload =
         createPayloadMap(
-            language,
-            source,
-            channel,
-            caseContainer,
-            userId,
-            null,
-            questionnaireId,
-            formType,
-            accountServiceUrl,
-            accountServiceLogoutUrl,
-            salt);
+            launchData, caseContainer, userId, null, accountServiceUrl, accountServiceLogoutUrl);
 
-    return codec.encrypt(payload, "authentication", keyStore);
+    return codec.encrypt(payload, "authentication", launchData.getKeyStore());
   }
 
-  public String getEqFlushLaunchJwe(
-      Language language,
-      Source source,
-      Channel channel,
-      String questionnaireId,
-      String formType,
-      KeyStore keyStore,
-      String salt)
-      throws CTPException {
+  @Override
+  public String getEqFlushLaunchJwe(EqLaunchData launchData) throws CTPException {
 
     Map<String, Object> payload =
-        createPayloadMap(
-            language,
-            source,
-            channel,
-            null,
-            null,
-            ROLE_FLUSHER,
-            questionnaireId,
-            formType,
-            null,
-            null,
-            salt);
+        createPayloadMap(launchData, null, null, ROLE_FLUSHER, null, null);
 
-    return codec.encrypt(payload, "authentication", keyStore);
+    return codec.encrypt(payload, "authentication", launchData.getKeyStore());
   }
 
   /**
@@ -109,18 +74,16 @@ public class EqLaunchServiceImpl implements EqLaunchService {
    * @throws CTPException
    */
   Map<String, Object> createPayloadMap(
-      Language language,
-      Source source,
-      Channel channel,
+      EqLaunchData launchData,
       CaseContainerDTO caseContainer,
       String userId,
       String role,
-      String questionnaireId,
-      String formType,
       String accountServiceUrl,
-      String accountServiceLogoutUrl,
-      String salt)
+      String accountServiceLogoutUrl)
       throws CTPException {
+
+    String questionnaireId = launchData.getQuestionnaireId();
+    Source source = launchData.getSource();
 
     long currentTimeInSeconds = System.currentTimeMillis() / 1000;
 
@@ -156,19 +119,19 @@ public class EqLaunchServiceImpl implements EqLaunchService {
                   caseContainer.getPostcode()));
       payload.computeIfAbsent("survey", (k) -> caseContainer.getSurveyType());
     }
-    String responseId = encryptResponseId(questionnaireId, salt);
-    payload.computeIfAbsent("language_code", (k) -> language.getIsoLikeCode());
+    String responseId = encryptResponseId(questionnaireId, launchData.getSalt());
+    payload.computeIfAbsent("language_code", (k) -> launchData.getLanguage().getIsoLikeCode());
     payload.computeIfAbsent("response_id", (k) -> responseId);
     payload.computeIfAbsent("account_service_url", (k) -> accountServiceUrl);
     payload.computeIfAbsent("account_service_log_out_url", (k) -> accountServiceLogoutUrl);
-    payload.computeIfAbsent("channel", (k) -> channel.name().toLowerCase());
+    payload.computeIfAbsent("channel", (k) -> launchData.getChannel().name().toLowerCase());
     payload.computeIfAbsent("user_id", (k) -> userId);
     payload.computeIfAbsent("roles", (k) -> role);
     payload.computeIfAbsent("questionnaire_id", (k) -> questionnaireId);
 
     payload.computeIfAbsent("eq_id", (k) -> "census"); // hardcoded for rehearsal
     payload.computeIfAbsent("period_id", (k) -> "2019"); // hardcoded for rehearsal
-    payload.computeIfAbsent("form_type", (k) -> formType);
+    payload.computeIfAbsent("form_type", (k) -> launchData.getFormType());
 
     log.with("payload", payload).debug("Payload for EQ");
 
@@ -234,7 +197,6 @@ public class EqLaunchServiceImpl implements EqLaunchService {
       byte[] bytes = md.digest(questionnaireId.getBytes());
       responseId.append((new String(Hex.encode(bytes)).substring(0, 16)));
     } catch (NoSuchAlgorithmException ex) {
-      log.with(questionnaireId);
       log.with(questionnaireId).error("No SHA-256 algorithm while encrypting questionnaire", ex);
       throw new CTPException(Fault.SYSTEM_ERROR, ex);
     }

--- a/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/EqLaunchServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/EqLaunchServiceImpl.java
@@ -234,8 +234,9 @@ public class EqLaunchServiceImpl implements EqLaunchService {
       byte[] bytes = md.digest(questionnaireId.getBytes());
       responseId.append((new String(Hex.encode(bytes)).substring(0, 16)));
     } catch (NoSuchAlgorithmException ex) {
-      log.error("SHA256 Hashing error for questionnaire id {}", questionnaireId);
-      throw new CTPException(Fault.SYSTEM_ERROR, ex.getMessage());
+      log.with(questionnaireId);
+      log.with(questionnaireId).error("No SHA-256 algorithm while encrypting questionnaire", ex);
+      throw new CTPException(Fault.SYSTEM_ERROR, ex);
     }
     return responseId.toString();
   }

--- a/src/test/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/TestEqLaunchService_payloadCreation.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/TestEqLaunchService_payloadCreation.java
@@ -4,13 +4,9 @@ import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import org.bouncycastle.util.encoders.Hex;
-import org.junit.Assert;
 import org.junit.Test;
 import uk.gov.ons.ctp.common.FixtureHelper;
 import uk.gov.ons.ctp.common.domain.Channel;
@@ -198,7 +194,7 @@ public class TestEqLaunchService_payloadCreation {
           + ", \"value\": \""
           + ENCRYPTION_PRIVATE_VALUE
           + "\"}}}";
-  private static String SALT = "CENSUS";
+  private static final String SALT = "CENSUS";
 
   /**
    * Calls both the public and package methods in the class under test and asserts that each returns
@@ -234,7 +230,7 @@ public class TestEqLaunchService_payloadCreation {
     expectedMap.put("case_id", caseId.toString());
     expectedMap.put("language_code", "en");
     expectedMap.put("display_address", "ONS, Segensworth\'s Road");
-    expectedMap.put("response_id", getEncryptResponseId("11100000009"));
+    expectedMap.put("response_id", "11100000009804def6a16184d28");
     expectedMap.put("account_service_url", "http://localhost:9092/start");
     expectedMap.put("account_service_log_out_url", "http://localhost:9092/start/save-and-exit");
     expectedMap.put("channel", "field");
@@ -341,7 +337,7 @@ public class TestEqLaunchService_payloadCreation {
     expectedMap.put("iat", "12345");
     expectedMap.put("exp", "12345");
     expectedMap.put("language_code", "en");
-    expectedMap.put("response_id", getEncryptResponseId("11100000009"));
+    expectedMap.put("response_id", "11100000009804def6a16184d28");
     expectedMap.put("channel", "rh");
     expectedMap.put("roles", "flusher");
     expectedMap.put("questionnaire_id", "11100000009");
@@ -413,7 +409,7 @@ public class TestEqLaunchService_payloadCreation {
     expectedMap.put("iat", "12345");
     expectedMap.put("exp", "12345");
     expectedMap.put("language_code", "en");
-    expectedMap.put("response_id", getEncryptResponseId("11100000009"));
+    expectedMap.put("response_id", "11100000009804def6a16184d28");
     expectedMap.put("channel", "cc");
     expectedMap.put("questionnaire_id", "11100000009");
     expectedMap.put("eq_id", "census");
@@ -495,18 +491,5 @@ public class TestEqLaunchService_payloadCreation {
     payloadMap.put("iat", "12345");
     payloadMap.put("exp", "12345");
     return payloadMap;
-  }
-
-  public String getEncryptResponseId(String questionnaireId) {
-    StringBuilder responseId = new StringBuilder(questionnaireId);
-    try {
-      MessageDigest md = MessageDigest.getInstance("SHA-256");
-      md.update(SALT.getBytes());
-      byte[] bytes = md.digest(questionnaireId.getBytes());
-      responseId.append((new String(Hex.encode(bytes)).substring(0, 16)));
-    } catch (NoSuchAlgorithmException e) {
-      Assert.fail("SHA256 Hashing error for questionnaire id " + questionnaireId);
-    }
-    return responseId.toString();
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/TestEqLaunchService_payloadCreation.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/TestEqLaunchService_payloadCreation.java
@@ -4,9 +4,13 @@ import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.Assert;
 import org.junit.Test;
 import uk.gov.ons.ctp.common.FixtureHelper;
 import uk.gov.ons.ctp.common.domain.Channel;
@@ -194,6 +198,7 @@ public class TestEqLaunchService_payloadCreation {
           + ", \"value\": \""
           + ENCRYPTION_PRIVATE_VALUE
           + "\"}}}";
+  private static String SALT = "CENSUS";
 
   /**
    * Calls both the public and package methods in the class under test and asserts that each returns
@@ -209,6 +214,7 @@ public class TestEqLaunchService_payloadCreation {
     EqLaunchServiceImpl eqLaunchService = new EqLaunchServiceImpl();
     KeyStore keyStoreEncryption = new KeyStore(JWTKEYS_ENCRYPTION);
     KeyStore keyStoreDecryption = new KeyStore(JWTKEYS_DECRYPTION);
+
     EQJOSEProvider codec = new Codec();
 
     // create expectation
@@ -228,7 +234,7 @@ public class TestEqLaunchService_payloadCreation {
     expectedMap.put("case_id", caseId.toString());
     expectedMap.put("language_code", "en");
     expectedMap.put("display_address", "ONS, Segensworth\'s Road");
-    expectedMap.put("response_id", "11100000009");
+    expectedMap.put("response_id", getEncryptResponseId("11100000009"));
     expectedMap.put("account_service_url", "http://localhost:9092/start");
     expectedMap.put("account_service_log_out_url", "http://localhost:9092/start/save-and-exit");
     expectedMap.put("channel", "field");
@@ -274,7 +280,8 @@ public class TestEqLaunchService_payloadCreation {
             questionnaireId,
             formType,
             accountServiceUrl,
-            accountServiceLogoutUrl);
+            accountServiceLogoutUrl,
+            SALT);
 
     assertEquals(
         "expectedMap should equal the cleaned map from the complex call",
@@ -293,7 +300,8 @@ public class TestEqLaunchService_payloadCreation {
             formType,
             accountServiceUrl,
             accountServiceLogoutUrl,
-            keyStoreEncryption);
+            keyStoreEncryption,
+            SALT);
 
     // decrypt it
     String decrypted = codec.decrypt(payloadStringFromSimpleCall, keyStoreDecryption);
@@ -333,7 +341,7 @@ public class TestEqLaunchService_payloadCreation {
     expectedMap.put("iat", "12345");
     expectedMap.put("exp", "12345");
     expectedMap.put("language_code", "en");
-    expectedMap.put("response_id", "11100000009");
+    expectedMap.put("response_id", getEncryptResponseId("11100000009"));
     expectedMap.put("channel", "rh");
     expectedMap.put("roles", "flusher");
     expectedMap.put("questionnaire_id", "11100000009");
@@ -360,7 +368,8 @@ public class TestEqLaunchService_payloadCreation {
             questionnaireId,
             formType,
             null,
-            null);
+            null,
+            SALT);
 
     assertEquals(
         "expectedMap should equal the cleaned map from the complex call",
@@ -370,7 +379,7 @@ public class TestEqLaunchService_payloadCreation {
     // Run code under test to get encrypted payload string
     String payloadStringFromSimpleCall =
         eqLaunchService.getEqFlushLaunchJwe(
-            language, source, channel, questionnaireId, formType, keyStoreEncryption);
+            language, source, channel, questionnaireId, formType, keyStoreEncryption, SALT);
 
     // decrypt it
     String decrypted = codec.decrypt(payloadStringFromSimpleCall, keyStoreDecryption);
@@ -404,7 +413,7 @@ public class TestEqLaunchService_payloadCreation {
     expectedMap.put("iat", "12345");
     expectedMap.put("exp", "12345");
     expectedMap.put("language_code", "en");
-    expectedMap.put("response_id", "11100000009");
+    expectedMap.put("response_id", getEncryptResponseId("11100000009"));
     expectedMap.put("channel", "cc");
     expectedMap.put("questionnaire_id", "11100000009");
     expectedMap.put("eq_id", "census");
@@ -442,7 +451,8 @@ public class TestEqLaunchService_payloadCreation {
             questionnaireId,
             formType,
             null,
-            accountServiceLogoutUrl);
+            accountServiceLogoutUrl,
+            SALT);
 
     assertEquals(
         "expectedMap should equal the cleaned map from the complex call",
@@ -461,7 +471,8 @@ public class TestEqLaunchService_payloadCreation {
             formType,
             null,
             accountServiceLogoutUrl,
-            keyStoreEncryption);
+            keyStoreEncryption,
+            SALT);
 
     // decrypt it
     String decrypted = codec.decrypt(payloadStringFromSimpleCall, keyStoreDecryption);
@@ -484,5 +495,18 @@ public class TestEqLaunchService_payloadCreation {
     payloadMap.put("iat", "12345");
     payloadMap.put("exp", "12345");
     return payloadMap;
+  }
+
+  public String getEncryptResponseId(String questionnaireId) {
+    StringBuilder responseId = new StringBuilder(questionnaireId);
+    try {
+      MessageDigest md = MessageDigest.getInstance("SHA-256");
+      md.update(SALT.getBytes());
+      byte[] bytes = md.digest(questionnaireId.getBytes());
+      responseId.append((new String(Hex.encode(bytes)).substring(0, 16)));
+    } catch (NoSuchAlgorithmException e) {
+      Assert.fail("SHA256 Hashing error for questionnaire id " + questionnaireId);
+    }
+    return responseId.toString();
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/TestEqLaunchService_payloadCreation.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/TestEqLaunchService_payloadCreation.java
@@ -16,6 +16,7 @@ import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerD
 import uk.gov.ons.ctp.integration.eqlaunch.crypto.Codec;
 import uk.gov.ons.ctp.integration.eqlaunch.crypto.EQJOSEProvider;
 import uk.gov.ons.ctp.integration.eqlaunch.crypto.KeyStore;
+import uk.gov.ons.ctp.integration.eqlaunch.service.EqLaunchData;
 
 public class TestEqLaunchService_payloadCreation {
 
@@ -264,20 +265,21 @@ public class TestEqLaunchService_payloadCreation {
     caseContainer.setPostcode("PO15 5RR");
     caseContainer.setSurveyType("CENSUS");
 
+    EqLaunchData launchData =
+        EqLaunchData.builder()
+            .language(language)
+            .source(source)
+            .channel(channel)
+            .questionnaireId(questionnaireId)
+            .formType(formType)
+            .keyStore(keyStoreEncryption)
+            .salt(SALT)
+            .build();
+
     // Run code under to test to get a payload
     Map<String, Object> payloadMapFromComplexCall =
         eqLaunchService.createPayloadMap(
-            language,
-            source,
-            channel,
-            caseContainer,
-            userId,
-            null,
-            questionnaireId,
-            formType,
-            accountServiceUrl,
-            accountServiceLogoutUrl,
-            SALT);
+            launchData, caseContainer, userId, null, accountServiceUrl, accountServiceLogoutUrl);
 
     assertEquals(
         "expectedMap should equal the cleaned map from the complex call",
@@ -287,17 +289,7 @@ public class TestEqLaunchService_payloadCreation {
     // Run code under test to get encrypted payload string
     String payloadStringFromSimpleCall =
         eqLaunchService.getEqLaunchJwe(
-            language,
-            source,
-            channel,
-            caseContainer,
-            userId,
-            questionnaireId,
-            formType,
-            accountServiceUrl,
-            accountServiceLogoutUrl,
-            keyStoreEncryption,
-            SALT);
+            launchData, caseContainer, userId, accountServiceUrl, accountServiceLogoutUrl);
 
     // decrypt it
     String decrypted = codec.decrypt(payloadStringFromSimpleCall, keyStoreDecryption);
@@ -352,20 +344,20 @@ public class TestEqLaunchService_payloadCreation {
     String questionnaireId = "11100000009";
     String formType = "H";
 
+    EqLaunchData launchData =
+        EqLaunchData.builder()
+            .language(language)
+            .source(source)
+            .channel(channel)
+            .questionnaireId(questionnaireId)
+            .formType(formType)
+            .keyStore(keyStoreEncryption)
+            .salt(SALT)
+            .build();
+
     // Run code under to test to get the payload map.
     Map<String, Object> payloadMapFromComplexCall =
-        eqLaunchService.createPayloadMap(
-            language,
-            source,
-            channel,
-            null,
-            null,
-            "flusher",
-            questionnaireId,
-            formType,
-            null,
-            null,
-            SALT);
+        eqLaunchService.createPayloadMap(launchData, null, null, "flusher", null, null);
 
     assertEquals(
         "expectedMap should equal the cleaned map from the complex call",
@@ -373,9 +365,7 @@ public class TestEqLaunchService_payloadCreation {
         cleanPayloadMap(payloadMapFromComplexCall));
 
     // Run code under test to get encrypted payload string
-    String payloadStringFromSimpleCall =
-        eqLaunchService.getEqFlushLaunchJwe(
-            language, source, channel, questionnaireId, formType, keyStoreEncryption, SALT);
+    String payloadStringFromSimpleCall = eqLaunchService.getEqFlushLaunchJwe(launchData);
 
     // decrypt it
     String decrypted = codec.decrypt(payloadStringFromSimpleCall, keyStoreDecryption);
@@ -435,20 +425,21 @@ public class TestEqLaunchService_payloadCreation {
     String agentId = "123456";
     String accountServiceLogoutUrl = "https://localhost/questionnaireSaved";
 
+    EqLaunchData launchData =
+        EqLaunchData.builder()
+            .language(language)
+            .source(source)
+            .channel(channel)
+            .questionnaireId(questionnaireId)
+            .formType(formType)
+            .keyStore(keyStoreEncryption)
+            .salt(SALT)
+            .build();
+
     // Run code under to test to get the payload map.
     Map<String, Object> payloadMapFromComplexCall =
         eqLaunchService.createPayloadMap(
-            language,
-            source,
-            channel,
-            caseData,
-            agentId,
-            null,
-            questionnaireId,
-            formType,
-            null,
-            accountServiceLogoutUrl,
-            SALT);
+            launchData, caseData, agentId, null, null, accountServiceLogoutUrl);
 
     assertEquals(
         "expectedMap should equal the cleaned map from the complex call",
@@ -458,17 +449,7 @@ public class TestEqLaunchService_payloadCreation {
     // Run code under test to get encrypted payload string
     String payloadStringFromSimpleCall =
         eqLaunchService.getEqLaunchJwe(
-            language,
-            source,
-            channel,
-            caseData,
-            agentId,
-            questionnaireId,
-            formType,
-            null,
-            accountServiceLogoutUrl,
-            keyStoreEncryption,
-            SALT);
+            launchData, caseData, agentId, null, accountServiceLogoutUrl);
 
     // decrypt it
     String decrypted = codec.decrypt(payloadStringFromSimpleCall, keyStoreDecryption);


### PR DESCRIPTION
Changed to encrypt response id from SALT and questionnaireId:
https://collaborate2.ons.gov.uk/jira/browse/CR-1205
https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=CATD&title=Census+Respondent+Home#CensusRespondentHome-ResponseIdgeneration