### PR TITLE
CR-1304 EQ Launch for CCS changed

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/EqLaunchServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/EqLaunchServiceImpl.java
@@ -68,7 +68,6 @@ public class EqLaunchServiceImpl implements EqLaunchService {
    * @param caseContainer case container
    * @param userId user id
    * @param role role
-   * @param questionnaireId questionnaire ID
    * @param accountServiceUrl service url
    * @param accountServiceLogoutUrl logout url
    * @return
@@ -107,7 +106,11 @@ public class EqLaunchServiceImpl implements EqLaunchService {
       String convertedRegionCode = convertRegionCode(caseContainer.getRegion());
       payload.computeIfAbsent("region_code", (k) -> convertedRegionCode);
       payload.computeIfAbsent(
-          "ru_ref", (k) -> source == FIELD_SERVICE ? caseIdStr : caseContainer.getUprn());
+          "ru_ref",
+          (k) ->
+              caseContainer.getSurveyType().equalsIgnoreCase("CCS")
+                  ? caseIdStr
+                  : caseContainer.getUprn());
       payload.computeIfAbsent("case_id", (k) -> caseIdStr);
       payload.computeIfAbsent(
           "display_address",

--- a/src/test/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/TestEqLaunchService_payloadCreation.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/TestEqLaunchService_payloadCreation.java
@@ -464,7 +464,6 @@ public class TestEqLaunchService_payloadCreation {
 
     // create expectation
     Map<String, Object> expectedMap = getExpectedMap(caseData);
-    //    expectedMap.remove("ru_ref");
 
     // create params for code under test
     Language language = Language.ENGLISH;

--- a/src/test/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/TestEqLaunchService_payloadCreation.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/TestEqLaunchService_payloadCreation.java
@@ -230,7 +230,7 @@ public class TestEqLaunchService_payloadCreation {
     expectedMap.put("case_type", "H");
     expectedMap.put("collection_exercise_sid", collectionExerciseId.toString());
     expectedMap.put("region_code", "GB-ENG");
-    expectedMap.put("ru_ref", caseId.toString());
+    expectedMap.put("ru_ref", uprn);
     expectedMap.put("case_id", caseId.toString());
     expectedMap.put("language_code", "en");
     expectedMap.put("display_address", "ONS, Segensworth\'s Road");
@@ -464,13 +464,12 @@ public class TestEqLaunchService_payloadCreation {
 
     // create expectation
     Map<String, Object> expectedMap = getExpectedMap(caseData);
-    expectedMap.remove("ru_ref");
+    //    expectedMap.remove("ru_ref");
 
     // create params for code under test
     Language language = Language.ENGLISH;
     Source source = Source.CONTACT_CENTRE_API;
     Channel channel = Channel.CC;
-    String questionnaireId = A_QUESTIONNAIRE_ID;
     String formType = "H";
     String agentId = "123456";
     String accountServiceLogoutUrl = "https://localhost/questionnaireSaved";
@@ -481,7 +480,7 @@ public class TestEqLaunchService_payloadCreation {
             .language(language)
             .source(source)
             .channel(channel)
-            .questionnaireId(questionnaireId)
+            .questionnaireId(A_QUESTIONNAIRE_ID)
             .formType(formType)
             .keyStore(keyStoreEncryption)
             .salt(SALT)
@@ -543,7 +542,11 @@ public class TestEqLaunchService_payloadCreation {
     expectedMap.put("case_type", caseData.getCaseType());
     expectedMap.put("collection_exercise_sid", caseData.getCollectionExerciseId().toString());
     expectedMap.put("region_code", "GB-ENG");
-    expectedMap.put("ru_ref", caseData.getUprn());
+    expectedMap.put(
+        "ru_ref",
+        caseData.getSurveyType().equalsIgnoreCase("CCS")
+            ? caseData.getId().toString()
+            : caseData.getUprn());
     expectedMap.put("case_id", caseData.getId().toString());
     expectedMap.put(
         "display_address", caseData.getAddressLine1() + ", " + caseData.getAddressLine2());


### PR DESCRIPTION
The CCSvc launch of CCS cases in EQ does not work as the ru_ref claim is not sent to EQ because the case has no UPRN. This has become evident as a side effect following testing of a recent change to CCSvc that allowed CCS cases having no UPRN to be launched.

Link:
https://collaborate2.ons.gov.uk/jira/browse/CR-1304