### PR TITLE
CR-1658 set period_id to 2021 instead of 2019

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/EqLaunchServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/EqLaunchServiceImpl.java
@@ -133,8 +133,8 @@ public class EqLaunchServiceImpl implements EqLaunchService {
     payload.computeIfAbsent("roles", (k) -> role);
     payload.computeIfAbsent("questionnaire_id", (k) -> questionnaireId);
 
-    payload.computeIfAbsent("eq_id", (k) -> "census"); // hardcoded for rehearsal
-    payload.computeIfAbsent("period_id", (k) -> "2019"); // hardcoded for rehearsal
+    payload.computeIfAbsent("eq_id", (k) -> "census");
+    payload.computeIfAbsent("period_id", (k) -> "2021");
     payload.computeIfAbsent("form_type", (k) -> coreData.getFormType());
 
     log.with("payload", payload).debug("Payload for EQ");

--- a/src/test/java/uk/gov/ons/ctp/integration/eqlaunch/crypto/CodecTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/eqlaunch/crypto/CodecTest.java
@@ -254,7 +254,7 @@ public class CodecTest {
     test.put("user_id", "");
     test.put("questionnaire_id", "11100000009");
     test.put("eq_id", "census");
-    test.put("period_id", "2019");
+    test.put("period_id", "2021");
     test.put("form_type", "H");
     test.put("survey", "CENSUS");
 

--- a/src/test/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/TestEqLaunchService_payloadCreation.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/eqlaunch/service/impl/TestEqLaunchService_payloadCreation.java
@@ -241,7 +241,7 @@ public class TestEqLaunchService_payloadCreation {
     expectedMap.put("user_id", "1234567890");
     expectedMap.put("questionnaire_id", A_QUESTIONNAIRE_ID);
     expectedMap.put("eq_id", "census");
-    expectedMap.put("period_id", "2019");
+    expectedMap.put("period_id", "2021");
     expectedMap.put("form_type", "H");
     expectedMap.put("survey", "CENSUS");
 
@@ -343,7 +343,7 @@ public class TestEqLaunchService_payloadCreation {
     expectedMap.put("roles", "flusher");
     expectedMap.put("questionnaire_id", A_QUESTIONNAIRE_ID);
     expectedMap.put("eq_id", "census");
-    expectedMap.put("period_id", "2019");
+    expectedMap.put("period_id", "2021");
     expectedMap.put("form_type", "H");
 
     // create params for code under test
@@ -536,7 +536,7 @@ public class TestEqLaunchService_payloadCreation {
     expectedMap.put("channel", "cc");
     expectedMap.put("questionnaire_id", A_QUESTIONNAIRE_ID);
     expectedMap.put("eq_id", "census");
-    expectedMap.put("period_id", "2019");
+    expectedMap.put("period_id", "2021");
     expectedMap.put("form_type", "H");
     expectedMap.put("case_type", caseData.getCaseType());
     expectedMap.put("collection_exercise_sid", caseData.getCollectionExerciseId().toString());


### PR DESCRIPTION

modernise the period_id attribute in the EQ launch token.